### PR TITLE
Use GitHub emails endpoint if the user:email scope is used

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "remix-auth-strategy-template",
+  "name": "remix-auth-github",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "remix-auth-strategy-template",
+      "name": "remix-auth-github",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,8 @@ export interface GitHubStrategyOptions {
   userAgent?: string;
 }
 
-export type GitHubEmails = [{ value: string }];
+export type GitHubEmails = OAuth2Profile["emails"];
+export type GitHubEmailsResponse = { email: string }[];
 
 export interface GitHubProfile extends OAuth2Profile {
   id: string;
@@ -25,7 +26,7 @@ export interface GitHubProfile extends OAuth2Profile {
     givenName: string;
     middleName: string;
   };
-  emails: [{ value: string }];
+  emails: GitHubEmails;
   photos: [{ value: string }];
   _json: {
     login: string;
@@ -136,8 +137,9 @@ export class GitHubStrategy<User> extends OAuth2Strategy<
       },
     });
 
-    let data: GitHubEmails = await response.json();
-    return data;
+    let data: GitHubEmailsResponse = await response.json();
+    let emails: GitHubEmails = data.map(({ email }) => ({ value: email }));
+    return emails;
   }
   protected async userProfile(accessToken: string): Promise<GitHubProfile> {
     let response = await fetch(this.userInfoURL, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export class GitHubStrategy<User> extends OAuth2Strategy<
 > {
   name = "github";
 
+  private USER_EMAIL_SCOPE = "user:email";
   private scope: string;
   private allowSignup: boolean;
   private userAgent: string;
@@ -117,7 +118,7 @@ export class GitHubStrategy<User> extends OAuth2Strategy<
       },
       verify
     );
-    this.scope = scope ?? "user:email";
+    this.scope = scope ?? this.USER_EMAIL_SCOPE;
     this.allowSignup = allowSignup ?? true;
     this.userAgent = userAgent ?? "Remix Auth";
   }
@@ -151,7 +152,15 @@ export class GitHubStrategy<User> extends OAuth2Strategy<
     });
     let data: GitHubProfile["_json"] = await response.json();
 
-    let emails = await this.userEmails(accessToken);
+    let emails: GitHubProfile["emails"] = [
+      {
+        value: data.email,
+      },
+    ];
+
+    if (this.scope.includes(this.USER_EMAIL_SCOPE)) {
+      emails = await this.userEmails(accessToken);
+    }
 
     let profile: GitHubProfile = {
       provider: "github",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -40,7 +40,7 @@ describe(GitHubStrategy, () => {
     }
   });
 
-  test("should have the scope `email` as default", async () => {
+  test("should have the scope `user:email` as default", async () => {
     let strategy = new GitHubStrategy(
       {
         clientID: "CLIENT_ID",
@@ -64,7 +64,7 @@ describe(GitHubStrategy, () => {
 
       let redirectUrl = new URL(location);
 
-      expect(redirectUrl.searchParams.get("scope")).toBe("email");
+      expect(redirectUrl.searchParams.get("scope")).toBe("user:email");
     }
   });
 


### PR DESCRIPTION
In order to get the user emails, you must use an additional endpoint `https://api.github.com/user/emails` and `user:email` scope.
