### PR TITLE
chore: use `ActionArgs`/`LoaderArgs` instead of `ActionFunction`/`LoaderFunction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ import type { ActionArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { authenticator } from "~/auth.server";
 
-export let loader = () => redirect("/login");
+export async function loader() {
+  return redirect("/login");
+}
 
-export let action = ({ request }: ActionArgs) => {
+export async function action({ request }: ActionArgs) {
   return authenticator.authenticate("github", request);
 };
 ```
@@ -66,7 +68,7 @@ export let action = ({ request }: ActionArgs) => {
 import type { LoaderArgs } from "@remix-run/node";
 import { authenticator } from "~/auth.server";
 
-export let loader = ({ request }: LoaderArgs) => {
+export async function loader({ request }: LoaderArgs) {
   return authenticator.authenticate("github", request, {
     successRedirect: "/dashboard",
     failureRedirect: "/login",

--- a/README.md
+++ b/README.md
@@ -50,23 +50,23 @@ export default function Login() {
 
 ```tsx
 // app/routes/auth/github.tsx
-import type { ActionFunction, LoaderFunction } from "@remix-run/node";
+import type { ActionArgs } from "@remix-run/node";
 import { redirect } from "@remix-run/node";
 import { authenticator } from "~/auth.server";
 
-export let loader: LoaderFunction = () => redirect("/login");
+export let loader = () => redirect("/login");
 
-export let action: ActionFunction = ({ request }) => {
+export let action = ({ request }: ActionArgs) => {
   return authenticator.authenticate("github", request);
 };
 ```
 
 ```tsx
 // app/routes/auth/github/callback.tsx
-import type { LoaderFunction } from "@remix-run/node";
+import type { LoaderArgs } from "@remix-run/node";
 import { authenticator } from "~/auth.server";
 
-export let loader: LoaderFunction = ({ request }) => {
+export let loader = ({ request }: LoaderArgs) => {
   return authenticator.authenticate("github", request, {
     successRedirect: "/dashboard",
     failureRedirect: "/login",


### PR DESCRIPTION
To comply with new usage of `useActionData`/`useLoaderData` hooks

---

Just like https://github.com/sergiodxa/remix-auth/pull/196