### PR TITLE
Exclude `undefined` from `GitHubEmails` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,7 @@ export type GitHubScope =
   | "codespace"
   | "workflow";
 
-export type GitHubEmails = OAuth2Profile["emails"];
+export type GitHubEmails = NonNullable<OAuth2Profile["emails"]>;
 export type GitHubEmailsResponse = { email: string }[];
 
 export interface GitHubProfile extends OAuth2Profile {


### PR DESCRIPTION
`emails` is optional in `OAuth2Profile`, so `OAuth2Profile["emails"]` returns `Array<{ ... }> | undefined`.

This causes a compilation error when the compiler option `exactOptionalPropertyTypes` is set.

```
node_modules/remix-auth-github/build/index.d.ts(15,18): error TS2430: Interface 'GitHubProfile' incorrectly extends interface 'OAuth2Profile'.
  Types of property 'emails' are incompatible.
    Type '{ value: string; type?: string; }[] | undefined' is not assignable to type '{ value: string; type?: string; }[]'.
      Type 'undefined' is not assignable to type '{ value: string; type?: string; }[]'.
```

[`emails` is always set](https://github.com/sergiodxa/remix-auth-github/blob/5442a41177383f95a569a16717cedce26c872799/src/index.ts#L155-L159), so I think it makes sense to remove the possibility of `undefined` from the type.