### PR TITLE
Export more types and improve scope usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ export interface GitHubStrategyOptions {
   userAgent?: string;
 }
 
+/**
+ * @see https://docs.github.com/en/developers/apps/building-oauth-apps/scopes-for-oauth-apps#available-scopes
+ */
 export type GitHubScope =
   | "repo"
   | "repo:status"
@@ -116,15 +119,15 @@ export interface GitHubExtraParams extends Record<string, string | number> {
 }
 
 export const GitHubStrategyDefaultName = "github";
-export const GitHubDefaultScope: GitHubScope = "user:email";
-export const GitHubScopeSeperator = " ";
+export const GitHubStrategyDefaultScope: GitHubScope = "user:email";
+export const GitHubStrategyScopeSeperator = " ";
 
 export class GitHubStrategy<User> extends OAuth2Strategy<
   User,
   GitHubProfile,
   GitHubExtraParams
 > {
-  name = GitHubDefaultName;
+  name = GitHubStrategyDefaultName;
 
   private scope: GitHubScope[];
   private allowSignup: boolean;
@@ -162,11 +165,11 @@ export class GitHubStrategy<User> extends OAuth2Strategy<
   }
 
   //Allow users the option to pass a scope string, or typed array
-  protected getScope(scope: GitHubStrategyOptions["scope"]) {
+  private getScope(scope: GitHubStrategyOptions["scope"]) {
     if (!scope) {
-      return [GitHubDefaultScope];
+      return [GitHubStrategyDefaultScope];
     } else if (typeof scope === "string") {
-      return scope.split(GitHubScopeSeperator) as GitHubScope[];
+      return scope.split(GitHubStrategyScopeSeperator) as GitHubScope[];
     }
 
     return scope;
@@ -174,7 +177,7 @@ export class GitHubStrategy<User> extends OAuth2Strategy<
 
   protected authorizationParams() {
     return new URLSearchParams({
-      scope: this.scope.join(GitHubScopeSeperator),
+      scope: this.scope.join(GitHubStrategyScopeSeperator),
       allow_signup: String(this.allowSignup),
     });
   }
@@ -207,7 +210,7 @@ export class GitHubStrategy<User> extends OAuth2Strategy<
       },
     ];
 
-    if (this.scope.includes(GitHubDefaultScope)) {
+    if (this.scope.includes(GitHubStrategyDefaultScope)) {
       emails = await this.userEmails(accessToken);
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ export interface GitHubExtraParams extends Record<string, string | number> {
   tokenType: string;
 }
 
-export const GitHubDefaultName = "github";
+export const GitHubStrategyDefaultName = "github";
 export const GitHubDefaultScope: GitHubScope = "user:email";
 export const GitHubScopeSeperator = " ";
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -46,6 +46,33 @@ describe(GitHubStrategy, () => {
     }
   });
 
+  test("should allow typed scope array", async () => {
+    let strategy = new GitHubStrategy(
+      {
+        clientID: "CLIENT_ID",
+        clientSecret: "CLIENT_SECRET",
+        callbackURL: "https://example.app/callback",
+        scope: ["read:user"],
+      },
+      verify
+    );
+
+    let request = new Request("https://example.app/auth/github");
+
+    try {
+      await strategy.authenticate(request, sessionStorage, BASE_OPTIONS);
+    } catch (error) {
+      if (!(error instanceof Response)) throw error;
+      let location = error.headers.get("Location");
+
+      if (!location) throw new Error("No redirect header");
+
+      let redirectUrl = new URL(location);
+
+      expect(redirectUrl.searchParams.get("scope")).toBe("read:user");
+    }
+  });
+
   test("should have the scope `user:email` as default", async () => {
     let strategy = new GitHubStrategy(
       {


### PR DESCRIPTION
Hey @sergiodxa!

I'm finally prepping remix-auth-socials to re-export packages like you suggested ages ago.

One of the things I'm doing is trying to update each package with a consistent feel before that though, the main one here just providing the option for using a typed scope array to the user.

I've also exported a few options (default scope / name, and scope separator) so that my package can use them easier, and allow you to see what's going on.

Let me know if you have any issues with it :D 