### PR TITLE
Support v2 of @remix-run/server-runtime peer deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "typescript": "^4.3.5"
       },
       "peerDependencies": {
-        "@remix-run/server-runtime": "^1.0.0",
+        "@remix-run/server-runtime": "^1.0.0 || ^2.0.0",
         "remix-auth": "^3.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@remix-run/server-runtime": "^1.0.0",
+    "@remix-run/server-runtime": "^1.0.0 || ^2.0.0",
     "remix-auth": "^3.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #29 

Updated peer deps version for @remix-run/server-runtime to "^1.0.0 || ^2.0.0"